### PR TITLE
Add email login feature

### DIFF
--- a/lib/screens/email_login.dart
+++ b/lib/screens/email_login.dart
@@ -1,0 +1,184 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+import 'package:hackathon_project/screens/email_signup.dart';
+
+import '../widgets/my_password_field.dart';
+import '../widgets/my_text_button.dart';
+import '../widgets/my_text_field.dart';
+
+class EmailLogin extends StatefulWidget {
+  const EmailLogin({super.key});
+
+  @override
+  _EmailLoginPageState createState() => _EmailLoginPageState();
+}
+
+class _EmailLoginPageState extends State<EmailLogin> {
+  bool isPasswordVisible = true;
+  final TextEditingController _emailController = TextEditingController();
+  final TextEditingController _passwordController = TextEditingController();
+
+  String _emailError = "";
+  String _passwordError = "";
+
+  Future<void> submit() async {
+    String email = _emailController.text;
+    String password = _passwordController.text;
+    if (email.isEmpty) {
+      setState(() {
+        _emailError = "Username required.";
+      });
+      return;
+    }
+    else{
+      setState(() {
+        _emailError = "";
+      });
+    }
+    if (password.isEmpty) {
+      setState(() {
+        _passwordError = "Password required.";
+      });
+      return;
+    }
+    try {
+      UserCredential userCredential = await FirebaseAuth.instance
+          .signInWithEmailAndPassword(
+          email: email, password: password);
+    } on FirebaseAuthException catch (e) {
+      if (e.code == 'user-not-found' || e.code == 'invalid-email') {
+        setState(() {
+          _emailError = "Invalid username";
+        });
+      } else if (e.code == 'wrong-password') {
+        setState(() {
+          _passwordError = "Incorrect password";
+        });
+      } else {
+        setState(() {
+          _emailError = e.code;
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        backgroundColor: const Color.fromRGBO(82, 45, 174, 1),
+        elevation: 0,
+        leading: IconButton(
+          onPressed: () {
+            Navigator.pop(context);
+          },
+          icon: const Icon(
+            Icons.arrow_back,
+            size: 24,
+            color: Colors.white,
+          ),
+        ),
+      ),
+      body: Container(
+        constraints: const BoxConstraints(minHeight: double.infinity),
+        color: const Color.fromRGBO(82, 45, 174, 1),
+        child: SafeArea(
+          //to make page scrollable
+          child: SingleChildScrollView(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 20),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Flexible(
+                    fit: FlexFit.loose,
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        const Text(
+                          "Welcome back.",
+                          style: TextStyle(
+                            color: Colors.white,
+                            fontSize: 34,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                        const SizedBox(
+                          height: 10,
+                        ),
+                        const Text(
+                          "You've been missed!",
+                          style: TextStyle(
+                              fontSize: 28,
+                              fontWeight: FontWeight.w500,
+                              color: Colors.white),
+                        ),
+                        const SizedBox(
+                          height: 60,
+                        ),
+                        MyTextField(
+                          errorText: _emailError,
+                          controller: _emailController,
+                          hintText: 'Email',
+                          inputType: TextInputType.text,
+                        ),
+                        MyPasswordField(
+                          errorText: _passwordError,
+                          controller: _passwordController,
+                          isPasswordVisible: isPasswordVisible,
+                          onTap: () {
+                            setState(() {
+                              isPasswordVisible = !isPasswordVisible;
+                            });
+                          },
+                        ),
+                      ],
+                    ),
+                  ),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      const Text(
+                        "Don't have an account? ",
+                        style: TextStyle(
+                          color: Colors.grey,
+                          fontSize: 15,
+                        ),
+                      ),
+                      GestureDetector(
+                        onTap: () {
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (context) => EmailSignup(),
+                            ),
+                          );
+                        },
+                        child: const Text(
+                          'Register',
+                          style: TextStyle(
+                            color: Colors.white,
+                            fontSize: 15,
+                          ),
+                        ),
+                      )
+                    ],
+                  ),
+                  const SizedBox(
+                    height: 20,
+                  ),
+                  MyTextButton(
+                    buttonName: 'Sign In',
+                    onTap: submit,
+                    bgColor: Colors.white,
+                    textColor: Colors.black87,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/email_signup.dart
+++ b/lib/screens/email_signup.dart
@@ -1,0 +1,217 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+import 'package:hackathon_project/models/user_model.dart';
+
+import '../widgets/my_password_field.dart';
+import '../widgets/my_text_button.dart';
+import '../widgets/my_text_field.dart';
+
+class EmailSignup extends StatefulWidget {
+  const EmailSignup({super.key});
+
+  @override
+  _EmailSignupState createState() => _EmailSignupState();
+}
+
+class _EmailSignupState extends State<EmailSignup> {
+  bool passwordVisibility = true;
+  final TextEditingController _nameController = TextEditingController();
+  final TextEditingController _emailController = TextEditingController();
+  final TextEditingController _passwordController = TextEditingController();
+  final TextEditingController _confirmController = TextEditingController();
+
+  String _nameError = "";
+  String _emailError = "";
+  String _passwordError = "";
+  String _confirmError = "";
+
+  Future<void> submit() async {
+    String name = _nameController.text;
+    String email = _emailController.text;
+    String password = _passwordController.text;
+    String confirm = _confirmController.text;
+
+    if (name.isEmpty) {
+      setState(() {
+        _nameError = "Name is required.";
+      });
+      return;
+    }
+    else{
+      setState(() {
+        _nameError = "";
+      });
+    }
+    if (email.isEmpty) {
+      setState(() {
+        _emailError = "Email is required.";
+      });
+      return;
+    }
+    else if (! RegExp(r"^[a-zA-Z0-9.a-zA-Z0-9!#$%&'*+-/=?^_`{|}~]+@[a-zA-Z0-9]+\.[a-zA-Z]+")
+        .hasMatch(email)) {
+      setState(() {
+        _emailError =
+        "Enter valid email";
+      });
+      return;
+    }
+    else{
+      setState(() {
+        _emailError = "";
+      });
+    }
+    if (password != confirm) {
+      setState(() {
+        _confirmError = "Passwords don't match.";
+      });
+      return;
+    }
+    try {
+      UserCredential userCredential = await FirebaseAuth.instance
+          .createUserWithEmailAndPassword(
+          email: email, password: password);
+      User firebaseUser = FirebaseAuth.instance.currentUser!;
+      CollectionReference usersCollection =
+      FirebaseFirestore.instance.collection("users");
+      UserModel user = UserModel(
+          id: firebaseUser.uid, name: name, email: email);
+      usersCollection.doc(user.id).set(user.toJson());
+    } on FirebaseAuthException catch (e) {
+      if (e.code == "weak-password") {
+        setState(() {
+          _passwordError = "Password too weak.";
+        });
+      } else if (e.code == "email-already-in-use") {
+        setState(() {
+          _emailError = "Username already registered.";
+        });
+      }
+    } catch (e) {
+      ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text("Some error occurred")));
+    }
+  }
+
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        backgroundColor: const Color.fromRGBO(82, 45, 174, 1),
+        elevation: 0,
+        leading: IconButton(
+          onPressed: () {
+            Navigator.pop(context);
+          },
+          icon: const Icon(
+            Icons.arrow_back,
+            size: 24,
+            color: Colors.white,
+          ),
+        ),
+      ),
+      body: Container(
+        constraints: BoxConstraints(minHeight: double.infinity),
+        color: const Color.fromRGBO(82, 45, 174, 1),
+        child: SafeArea(
+          child: SingleChildScrollView(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(
+                horizontal: 20,
+              ),
+              child: Column(
+                children: [
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      const Text(
+                        "Register",
+                        style: TextStyle(
+                          color: Colors.white,
+                          fontSize: 34,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      const Text(
+                        "Create new account to get started.",
+                        style: TextStyle(
+                            fontSize: 28,
+                            fontWeight: FontWeight.w500,
+                            color: Colors.white),
+                      ),
+                      const SizedBox(
+                        height: 50,
+                      ),
+                      MyTextField(
+                        errorText:  _nameError,
+                        controller: _nameController,
+                        hintText: 'Name',
+                        inputType: TextInputType.name,
+                      ),
+                      MyTextField(
+                        errorText: _emailError,
+                        controller: _emailController,
+                        hintText: 'Email',
+                        inputType: TextInputType.emailAddress,
+                      ),
+                      MyPasswordField(
+                        errorText: _passwordError,
+                        controller: _passwordController,
+                        isPasswordVisible: passwordVisibility,
+                        onTap: () {
+                          setState(() {
+                            passwordVisibility = !passwordVisibility;
+                          });
+                        },
+                      ),
+                      MyTextField(
+                        errorText: _confirmError,
+                        controller: _confirmController,
+                        hintText: 'Confirm Password',
+                        inputType: TextInputType.text,
+                      ),
+                    ],
+                  ),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children:  [
+                      const Text(
+                        "Already have an account? ",
+                        style: TextStyle(
+                          color: Colors.grey,
+                          fontSize: 15,
+                        ),
+                      ),
+                      GestureDetector(
+                        onTap: (){
+                          Navigator.of(context).pop();
+                        },
+                        child: const Text(
+                          "Sign In",
+                          style: TextStyle(
+                            color: Colors.white,
+                            fontSize: 15,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(
+                    height: 20,
+                  ),
+                  MyTextButton(
+                    buttonName: 'Register',
+                    onTap: submit,
+                    bgColor: Colors.white,
+                    textColor: Colors.black87,
+                  )
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -10,6 +10,7 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:hackathon_project/models/user_model.dart';
+import 'package:hackathon_project/screens/email_login.dart';
 import 'package:hackathon_project/screens/tabs_screen.dart';
 import 'package:http/http.dart' as http;
 
@@ -175,8 +176,41 @@ class LoginScreen extends StatelessWidget {
                       color: Colors.white),
                 ),
                 const SizedBox(
-                  height: 250,
+                  height: 200,
                 ),
+                Builder(builder: (context) {
+                  return GestureDetector(
+                    onTap: () => Navigator.push(context, MaterialPageRoute(builder: (context)=>EmailLogin())),
+                    child: Container(
+                      width: 300,
+                      height: 60,
+                      decoration: const BoxDecoration(
+                        color: Colors.white,
+                        borderRadius: BorderRadius.all(
+                          Radius.circular(9),
+                        ),
+                      ),
+                      child: Center(
+                        child: Row(
+                          children: [
+                            Container(
+                                margin: EdgeInsets.all(8),
+                                child: const Icon(Icons.email,size: 42)),
+                             const SizedBox(
+                              width: 10,
+                            ),
+                            Text(
+                              'Login with Email',
+                              style: GoogleFonts.inter(
+                                  fontSize: 20, fontWeight: FontWeight.w500),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  );
+                }),
+                const SizedBox(height: 20,),
                 Builder(builder: (context) {
                   return GestureDetector(
                     onTap: () => auth(context),

--- a/lib/widgets/my_password_field.dart
+++ b/lib/widgets/my_password_field.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+
+class MyPasswordField extends StatelessWidget {
+  const MyPasswordField({
+    Key? key,
+    required this.isPasswordVisible,
+    required this.onTap,
+    required this.controller,
+    this.errorText,
+  }) : super(key: key);
+  final TextEditingController controller;
+  final bool isPasswordVisible;
+  final void Function() onTap;
+  final String? errorText;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 10),
+      child: TextField(
+        controller: controller,
+        style: const TextStyle(
+          color: Colors.white,
+          fontSize: 15,
+        ),
+        obscureText: isPasswordVisible,
+        keyboardType: TextInputType.text,
+        textInputAction: TextInputAction.done,
+        decoration: InputDecoration(
+          errorText: errorText == "" ? null : errorText,
+          suffixIcon: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 8.0),
+            child: IconButton(
+              splashColor: Colors.transparent,
+              highlightColor: Colors.transparent,
+              onPressed: onTap,
+              icon: Icon(
+                isPasswordVisible ? Icons.visibility : Icons.visibility_off,
+                color: Colors.grey,
+              ),
+            ),
+          ),
+          contentPadding: EdgeInsets.all(20),
+          hintText: 'Password',
+          hintStyle: const TextStyle(
+            color: Colors.grey,
+            fontSize: 15,
+          ),
+          errorBorder: OutlineInputBorder(
+            borderSide: const BorderSide(
+              color: Colors.grey,
+              width: 1,
+            ),
+            borderRadius: BorderRadius.circular(18),
+          ),
+          enabledBorder: OutlineInputBorder(
+            borderSide: const BorderSide(
+              color: Colors.grey,
+              width: 1,
+            ),
+            borderRadius: BorderRadius.circular(18),
+          ),
+          focusedBorder: OutlineInputBorder(
+            borderSide: const BorderSide(
+              color: Colors.white,
+              width: 1,
+            ),
+            borderRadius: BorderRadius.circular(18),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/my_text_button.dart
+++ b/lib/widgets/my_text_button.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+
+class MyTextButton extends StatelessWidget {
+  const MyTextButton({
+    Key? key,
+    required this.buttonName,
+    required this.onTap,
+    required this.bgColor,
+    required this.textColor,
+  }) : super(key: key);
+  final String buttonName;
+  final void Function() onTap;
+  final Color bgColor;
+  final Color textColor;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 60,
+      width: double.infinity,
+      decoration: BoxDecoration(
+        color: bgColor,
+        borderRadius: BorderRadius.circular(18),
+      ),
+      child: TextButton(
+        style: ButtonStyle(
+          overlayColor: MaterialStateProperty.resolveWith(
+            (states) => Colors.black12,
+          ),
+        ),
+        onPressed: onTap,
+        child: Text(
+          buttonName,
+          style: TextStyle(
+            color: textColor,
+            fontSize: 15,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/my_text_field.dart
+++ b/lib/widgets/my_text_field.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+
+class MyTextField extends StatelessWidget {
+  MyTextField({
+    Key? key,
+    required this.hintText,
+    required this.inputType,
+    required this.controller,
+    this.errorText,
+  }) : super(key: key);
+  final TextEditingController controller;
+  final String hintText;
+  final TextInputType inputType;
+  final String? errorText;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 10),
+      child: TextField(
+        controller: controller,
+        style: const TextStyle(
+          color: Colors.white,
+          fontSize: 15,
+        ),
+        keyboardType: inputType,
+        textInputAction: TextInputAction.next,
+        decoration: InputDecoration(
+          errorText: errorText == "" ? null : errorText,
+          contentPadding: const EdgeInsets.all(20),
+          hintText: hintText,
+          hintStyle: const TextStyle(
+            color: Colors.grey,
+            fontSize: 15,
+          ),
+          errorBorder: OutlineInputBorder(
+            borderSide: const BorderSide(
+              color: Colors.grey,
+              width: 1,
+            ),
+            borderRadius: BorderRadius.circular(18),
+          ),
+          enabledBorder: OutlineInputBorder(
+            borderSide: const BorderSide(
+              color: Colors.grey,
+              width: 1,
+            ),
+            borderRadius: BorderRadius.circular(18),
+          ),
+          focusedBorder: OutlineInputBorder(
+            borderSide: const BorderSide(
+              color: Colors.white,
+              width: 1,
+            ),
+            borderRadius: BorderRadius.circular(18),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Closes #1 

![WhatsApp Image 2022-12-07 at 16 06 40](https://user-images.githubusercontent.com/95132851/206157004-d7e078e6-0c92-4a7a-9e3d-6b600c4c4f2d.jpg)
![WhatsApp Image 2022-12-07 at 16 06 41](https://user-images.githubusercontent.com/95132851/206156992-ce3195c1-e5d5-4987-b850-e3edf33de58d.jpg)
![WhatsApp Image 2022-12-07 at 16 06 42](https://user-images.githubusercontent.com/95132851/206157002-10c454ec-619f-45c7-9b1d-ad1e9ebb9e59.jpg)

- [x] In [Login Screen](https://github.com/letsintegreat/Tagify/blob/main/lib/screens/login_screen.dart), add another button
- [x] You have to create two pages for Log in and Sign up separately. As you can see in the [User Model](https://github.com/letsintegreat/Tagify/blob/main/lib/models/user_model.dart), we also need the name of the user, so take name as an input from user in Sign up page.
- [x] Take the inspiration from Google auth code, and implement the logic of adding the user to the Firestore database, when the user creates a new 




